### PR TITLE
Update Milandr.MDR1986BExx.pdsc

### DIFF
--- a/Milandr.MDR1986BExx.pdsc
+++ b/Milandr.MDR1986BExx.pdsc
@@ -15,7 +15,7 @@
   </releases>
 
   <devices>
-    <family Dfamily="Milandr" Dvendor="Milandr:99">
+    <family Dfamily="MDR1986" Dvendor="Milandr:99">
       <subFamily DsubFamily="Cortex-M3">
         <!-- MDR1986BE91 -->
         <device Dname="MDR1986BE91">


### PR DESCRIPTION
При использовании пакета в Atollic TrueStudio при попытке выбора целевого устройства список миландра зацикливается (Milandr->Mcu->Milandr->Mcu и так пока пользователю не надоест). Решается путем названия семейства устройства именем, отличным от имени производителя.